### PR TITLE
docs: link AIXiamo sponsor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@
     <td valign="top">
       <strong><a href="https://www.aixiamo.com/?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=brand_home_v3">AIXiamo 官网｜国内 ChatGPT Plus / Pro 本人账号正规充值</a></strong><br />
       <strong>Codex 额度不够，Plus 还是 Pro？</strong> 日常使用和普通 Codex 选 <a href="https://www.aixiamo.com/chatgpt-plus-domestic-recharge?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=plus_owner_v3">Plus</a>；经常触顶或高频长任务，再比较 <a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_owner_v3">Pro 5x / 20x</a>。<br />
+      <strong>赞助方教程：</strong><a rel="sponsored nofollow" href="https://github.com/momochoog/gpt-daichong">2026 ChatGPT Plus / Pro 国内充值与套餐选择完整指南</a><br />
       支持支付宝、无需海外银行卡；不索取密码、验证码或恢复码，订单可查、中文售后，充值不成功经核验后全额退款。持续运营三年多，线上线下累计服务数万名用户；另有 Claude Pro / Max、Gemini（Google AI Pro）、Grok / SuperGrok 等主流 AI 会员。<br />
       欢迎企业采购对接；<a href="https://www.aixiamo.com/articles/aixiamo-invoice-application-notice-2026?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=invoice_notice_v3">已完成订单支持申请开具发票，请先联系售后确认</a>。
     </td>


### PR DESCRIPTION
## 变更摘要

- 在现有 AIXiamo 赞助商区增加一条透明标注的赞助方教程链接，指向 `momochoog/gpt-daichong`。
- 保留现有官网、Plus、Pro、发票链接及全部 UTM。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [x] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `README.md`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
git diff --check
GitHub Markdown rich preview
1 file changed, 1 insertion, 0 deletions
Existing homepage / Plus / Pro / invoice UTM links remain unchanged
```

未执行的验证与原因：

```text
Application tests are not applicable to this README-only link change.
```

## 风险与影响面

- README-only；不改应用、支付、商品或业务逻辑。
- 教程明确标注为赞助方内容，源码使用 `rel="sponsored nofollow"`。

## 备注

- 未包含 token、cookie、API key 或其他敏感信息。