### PR TITLE
fix(codex-profile): 修复直连账号切换兼容性与超时风险

### DIFF
--- a/apps/src/app/platform-mode/use-platform-mode-state.ts
+++ b/apps/src/app/platform-mode/use-platform-mode-state.ts
@@ -28,14 +28,22 @@ const RELOAD_AFTER_SWITCH_STORAGE_KEY =
   "codexmanager.platform-mode.reload-after-switch";
 const RELOAD_AFTER_SWITCH_EVENT =
   "codexmanager:platform-mode-reload-after-switch";
+const SAFE_RELOAD_DEFAULT_MIGRATION_KEY =
+  "codexmanager.platform-mode.reload-safe-default-v2";
 
-let reloadAfterSwitchMemoryValue = true;
+let reloadAfterSwitchMemoryValue = false;
 
 function getReloadAfterSwitchPreference(): boolean {
   if (typeof window === "undefined") {
     return reloadAfterSwitchMemoryValue;
   }
   try {
+    if (window.localStorage.getItem(SAFE_RELOAD_DEFAULT_MIGRATION_KEY) !== "1") {
+      // Older versions enabled process termination by default. Reset that inherited preference
+      // once; users can explicitly opt in again after the migration.
+      window.localStorage.setItem(RELOAD_AFTER_SWITCH_STORAGE_KEY, "false");
+      window.localStorage.setItem(SAFE_RELOAD_DEFAULT_MIGRATION_KEY, "1");
+    }
     const stored = window.localStorage.getItem(RELOAD_AFTER_SWITCH_STORAGE_KEY);
     if (stored === "true" || stored === "false") {
       reloadAfterSwitchMemoryValue = stored === "true";
@@ -115,7 +123,7 @@ export function usePlatformModePageState(
   const reloadAfterSwitch = useSyncExternalStore(
     subscribeToReloadAfterSwitchPreference,
     getReloadAfterSwitchPreference,
-    () => true,
+    () => false,
   );
   const browserOrigin = useSyncExternalStore(
     () => () => undefined,

--- a/apps/tests/codex-profile-cache.test.mjs
+++ b/apps/tests/codex-profile-cache.test.mjs
@@ -103,6 +103,8 @@ test("平台模式切换透传并持久化 Codex 后台重载开关", async () =
   const tauri = await readSource("src-tauri/src/commands/codex_profile.rs");
 
   assert.match(state, /codexmanager\.platform-mode\.reload-after-switch/);
+  assert.match(state, /reloadAfterSwitchMemoryValue = false/);
+  assert.match(state, /reload-safe-default-v2/);
   assert.match(state, /reloadAfterSwitch,/);
   assert.match(sections, /切换后重载 Codex 后台/);
   assert.match(client, /reloadAfterSwitch: params\.reloadAfterSwitch/);

--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -353,17 +353,13 @@ pub(crate) fn apply_direct_account(
             account_id: Some(account.id.clone()),
             api_key_id: None,
             gateway_base_url: None,
-            provider_id: PROVIDER_ID.to_string(),
+            provider_id: DEFAULT_HISTORY_PROVIDER_ID.to_string(),
             previous_model_catalog_json: None,
             updated_at: now_ts(),
         },
     )?;
     persist_codex_home(&profile_dir)?;
-    status_for_profile_after_apply(
-        &profile_dir,
-        DEFAULT_HISTORY_PROVIDER_ID,
-        reload_after_switch,
-    )
+    status_for_profile_after_apply(&profile_dir, None, reload_after_switch)
 }
 
 pub(crate) fn apply_gateway(
@@ -432,7 +428,7 @@ pub(crate) fn apply_gateway(
         },
     )?;
     persist_codex_home(&profile_dir)?;
-    status_for_profile_after_apply(&profile_dir, PROVIDER_ID, reload_after_switch)
+    status_for_profile_after_apply(&profile_dir, Some(PROVIDER_ID), reload_after_switch)
 }
 
 pub(crate) fn restore(codex_home: Option<&str>) -> Result<CodexProfileStatus, String> {
@@ -814,10 +810,16 @@ fn status_for_profile_with_history_repair(
 
 fn status_for_profile_after_apply(
     profile_dir: &Path,
-    target_provider: &str,
+    history_provider: Option<&str>,
     reload_after_switch: bool,
 ) -> Result<CodexProfileStatus, String> {
-    let mut status = status_for_profile_with_history_repair(profile_dir, target_provider)?;
+    // Direct mode keeps a secret-free `cm` compatibility provider, so existing conversations do
+    // not need a synchronous full-profile history rewrite. Gateway mode still repairs history so
+    // existing conversations are routed through the managed provider.
+    let mut status = match history_provider {
+        Some(provider) => status_for_profile_with_history_repair(profile_dir, provider)?,
+        None => status_for_profile(profile_dir)?,
+    };
     status.runtime_reload = Some(if reload_after_switch {
         crate::codex_runtime::reload_codex_app_servers(profile_dir)
     } else {
@@ -1971,23 +1973,22 @@ fn patch_config_for_direct(
     previous_model_catalog_json: Option<&str>,
 ) -> Result<String, String> {
     let mut doc = parse_config(content.as_deref().unwrap_or(""))?;
-    if doc
-        .get("model_provider")
-        .and_then(Item::as_str)
-        .is_some_and(|provider| provider == PROVIDER_ID)
-    {
-        doc.as_table_mut().remove("model_provider");
+    doc.as_table_mut()
+        .insert("model_provider", toml_value(DEFAULT_HISTORY_PROVIDER_ID));
+    if doc.as_table().get("model_providers").is_none() {
+        doc.as_table_mut()
+            .insert("model_providers", Item::Table(Table::new()));
     }
-    if let Some(providers) = doc
+    let providers = doc
         .as_table_mut()
         .get_mut("model_providers")
         .and_then(Item::as_table_mut)
-    {
-        providers.remove(PROVIDER_ID);
-        if providers.is_empty() {
-            doc.as_table_mut().remove("model_providers");
-        }
-    }
+        .ok_or_else(|| "config.toml model_providers is not a table".to_string())?;
+    let mut compatibility_provider = Table::new();
+    compatibility_provider.insert("name", toml_value("OpenAI compatibility"));
+    compatibility_provider.insert("wire_api", toml_value("responses"));
+    compatibility_provider.insert("requires_openai_auth", toml_value(true));
+    providers.insert(PROVIDER_ID, Item::Table(compatibility_provider));
     let managed_catalog_path = managed_catalog_path.to_string_lossy();
     let catalog_is_managed = doc
         .get("model_catalog_json")

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -119,7 +119,7 @@ fn sqlite_provider(dir: &Path, thread_id: &str) -> String {
 }
 
 #[test]
-fn direct_config_removes_only_managed_provider() {
+fn direct_config_uses_openai_and_keeps_secret_free_legacy_provider() {
     let input = r#"
 model_provider = "cm"
 model = "gpt-5.4"
@@ -128,6 +128,8 @@ model = "gpt-5.4"
 name = "CodexManager"
 base_url = "http://localhost:48760/v1"
 wire_api = "responses"
+experimental_bearer_token = "must-be-removed"
+custom_header = "must-also-be-removed"
 
 [model_providers.other]
 name = "Other"
@@ -138,8 +140,13 @@ base_url = "https://example.test/v1"
     let output = patch_config_for_direct(Some(input.to_string()), &managed_catalog, None)
         .expect("patch direct");
 
-    assert!(!output.contains("model_provider = \"cm\""));
-    assert!(!output.contains("[model_providers.cm]"));
+    assert!(output.contains("model_provider = \"openai\""));
+    assert!(output.contains("[model_providers.cm]"));
+    assert!(output.contains("wire_api = \"responses\""));
+    assert!(output.contains("requires_openai_auth = true"));
+    assert!(!output.contains("base_url = \"http://localhost:48760/v1\""));
+    assert!(!output.contains("experimental_bearer_token"));
+    assert!(!output.contains("custom_header"));
     assert!(output.contains("[model_providers.other]"));
     assert!(output.contains("model = \"gpt-5.4\""));
 }


### PR DESCRIPTION
## 变更摘要

- 修复账号切换到“直接连接 OpenAI”后，历史对话仍引用 `cm` 时出现 `Model provider 'cm' not found` 的问题。
- 直连模式显式使用内置 `openai` provider，并保留一个不含网关地址和密钥的 `cm` 兼容映射。
- 直连切换不再同步扫描并重写整个 Codex 历史目录，避免凭证已写入后 RPC 长时间阻塞；网关模式仍保留原有历史修复行为。
- “切换后重载 Codex 后台”改为默认关闭，并对旧版默认开启的偏好执行一次安全迁移；用户仍可主动开启。

## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/codex_profile.rs`
- `crates/service/src/codex_profile_tests.rs`
- `apps/src/app/platform-mode/use-platform-mode-state.ts`
- `apps/tests/codex-profile-cache.test.mjs`

## 验证

- [x] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo fmt --all -- --check
# PASS

git diff --check
# PASS

cargo test -p codexmanager-service codex_profile::tests:: -- --test-threads=1
# PASS: 28 passed, 0 failed

pnpm -C apps run lint
# PASS

pnpm -C apps run test:runtime
# PASS: 191 passed, 0 failed

pnpm -C apps run build:desktop
# PASS: Next.js static export completed

敏感信息扫描
# PASS: private key / OpenAI key / JWT / email / local credential matches = 0
```

未执行或未完全通过的验证与原因：

```text
pnpm -C apps run test:navigation
# Playwright webServer 未能启动：本机拒绝监听固定端口 127.0.0.1:3200（EACCES）。
# 测试用例尚未开始执行，不是断言失败。

pnpm -C apps run test:ui
# 未执行完整 UI 套件；本次改动没有新增页面结构，运行时测试和静态构建已覆盖改动边界。

cargo test --workspace
# 未执行完整 workspace；改动局限于 codex_profile，已运行该模块全部 28 项测试。

真实账号切换
# 未在上游干净工作区使用真实 token 重复切换，避免刷新令牌竞争和敏感数据进入测试环境。
```

## 风险与影响面

- 仅切换到直连模式时，`model_provider` 会明确写为 `openai`。
- 直连模式下的 `[model_providers.cm]` 只保留 `wire_api = "responses"` 和 `requires_openai_auth = true`；旧网关 `base_url`、Bearer token 和自定义认证字段会被移除，避免旧对话继续请求本地网关。
- 网关模式仍使用 `cm`，仍执行原有历史修复，现有网关 provider 合并规则不变。
- 重载偏好会在升级后安全重置一次；用户之后仍可显式重新开启。
- 不修改账号数据库、token 存储、网关路由、模型目录生成或发布流程。

## 备注

- 与 #399 不冲突：#399 保留网关模式下的自定义 `cm` 字段；本 PR 只在切回官方直连时把 `cm` 转为无密钥的 OpenAI 兼容映射。
- 已确认提交不包含真实 token、cookie、API key、账号数据或本机路径。