### PR TITLE
fix(codex-profile): 兼容 Codex 0.149 网关认证

### DIFF
--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -2044,6 +2044,8 @@ fn patch_config_for_gateway(
     if provider.get("name").is_none() {
         provider.insert("name", toml_value("CodexManager"));
     }
+    // Codex 0.149+ no longer inherits ambient auth for custom model providers.
+    provider.insert("requires_openai_auth", toml_value(true));
     provider.insert("base_url", toml_value(base_url));
     provider.insert("wire_api", toml_value("responses"));
     provider.insert("supports_websockets", toml_value(supports_websockets));

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -167,6 +167,7 @@ name = "Other"
     assert!(output.contains("name = \"CodexManager\""));
     assert!(output.contains("base_url = \"http://127.0.0.1:48770/v1\""));
     assert!(output.contains("wire_api = \"responses\""));
+    assert!(output.contains("requires_openai_auth = true"));
     assert!(output.contains("supports_websockets = true"));
     assert!(output.contains("model_catalog_json = \"/tmp/codexmanager/gateway-models.json\""));
     assert!(output.contains("[model_providers.other]"));
@@ -190,6 +191,7 @@ model_provider = "cm"
 name = "Custom Gateway"
 base_url = "https://stale.example.test/v1"
 wire_api = "chat"
+requires_openai_auth = false
 supports_websockets = false
 experimental_bearer_token = "custom-key"
 custom_header = "custom-value"
@@ -232,6 +234,10 @@ custom_header = "custom-value"
     assert_eq!(
         provider.get("wire_api").and_then(Item::as_str),
         Some("responses")
+    );
+    assert_eq!(
+        provider.get("requires_openai_auth").and_then(Item::as_bool),
+        Some(true)
     );
     assert_eq!(
         provider.get("supports_websockets").and_then(Item::as_bool),


### PR DESCRIPTION
## 问题

Codex CLI 0.149 起，自定义 model provider 不再隐式继承 OpenAI 登录认证。CodexManager 生成的 `cm` provider 缴少 `requires_openai_auth`，因此请求 `http://localhost:48760/v1/responses` 时不会携带 API key，网关返回 `401 Unauthorized: missing api key`。

Closes #443

## 修改

- `crates/service/src/codex_profile.rs`
  - 为 CodexManager 托管的 `[model_providers.cm]` 固定写入 `requires_openai_auth = true`。
  - 每次同步都会修复已有的 `false` 值，避免旧 profile 在升级 Codex 后继续报 401。
- `crates/service/src/codex_profile_tests.rs`
  - 覆盖新建网关配置写入该字段。
  - 覆盖已有 `requires_openai_auth = false` 被修正为 `true`，同时保留其他自定义 provider 字段。

## 影响范围

- 仅影响 CodexManager 托管的 `cm` 网关 provider。
- 不改变网关 API、存储格式或 direct account 模式。
- 不写入新的密钥；该字段只让 Codex 使用现有认证信息向本地网关发送 Authorization header。

## 验证

- `cargo fmt --all -- --check`：通过
- `cargo test -p codexmanager-service gateway_config_ -- --nocapture`：3 通过，0 失败
- `cargo test --workspace`：完整运行中 1412 通过、2 失败、3 忽略；两个失败均位于本次未修改的测试：
  - `account::delete_many::tests::delete_accounts_dedupes_ids_and_reports_missing_accounts`：隔离复跑通过
  - `codex_skills::tests::directory_import_detects_same_size_file_replacement_and_fifo_entries`：隔离复跑仍因 `source skill entry escaped its root` 失败

## 风险

低。变更会强制托管网关 profile 要求 OpenAI 认证，这与 CodexManager 网关本身要求 API key 的行为一致；用户的其他 provider 和自定义字段不受影响。
