### PR TITLE
ci: 提高 Cargo Git 依赖获取稳定性

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  CARGO_NET_RETRY: "3"
 
 jobs:
   rust_workspace:
@@ -56,6 +58,23 @@ jobs:
 
       - name: Setup release environment
         uses: ./.github/actions/setup-release-env
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Fetch Rust dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if cargo fetch --locked; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Install frontend dependencies
         working-directory: apps


### PR DESCRIPTION
## 摘要

修复 CI 中 `codexmanager-web` 测试因 Cargo Git 依赖瞬时 SSL/Git fetch 失败而中断的问题。

## 修改内容

- 启用 Cargo CLI Git fetch；
- 设置 Cargo 网络重试次数；
- 为 Web 测试 job 增加 Rust 依赖缓存；
- 在 `cargo fetch --locked` 阶段增加最多 3 次有界重试；
- 测试命令本身仍只执行一次，真实编译或测试失败不会被重试掩盖。

## 验证

本地已通过：

- `git diff --check`；
- `actionlint .github/workflows/ci.yml`；
- `CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_NET_RETRY=3 cargo fetch --locked`；
- `cargo test -p codexmanager-web --no-fail-fast`（26 passed）。