### PR TITLE
fix(gateway): recover duplicate Responses tool outputs

### DIFF
--- a/crates/service/src/http/responses_websocket.rs
+++ b/crates/service/src/http/responses_websocket.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::net::IpAddr;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -59,6 +60,13 @@ const RESPONSES_WS_MAX_PENDING_FRAME_SEND_ATTEMPTS: usize = 2;
 // A response can emit only connection preamble events before a transport reset. Reconnect the
 // lane at most twice in that state; once substantive output exists, replay is not safe.
 const RESPONSES_WS_MAX_PRE_COMPLETION_RECOVERY_ATTEMPTS: u8 = 2;
+// Tool-call output can arrive in a new frontend task after the upstream websocket was closed.
+// Retain only the call descriptors needed to make that output self-contained; response history
+// is intentionally not retained here because it was the source of the previous over-broad fix.
+const RESPONSES_WS_TOOL_CALL_REGISTRY_TTL: Duration = Duration::from_secs(30 * 60);
+const RESPONSES_WS_MAX_TOOL_CALL_REGISTRIES: usize = 128;
+const RESPONSES_WS_MAX_TOOL_CALL_REGISTRY_BYTES: usize = 32 * 1024 * 1024;
+const RESPONSES_WS_MAX_TOOL_CALL_ENTRY_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone)]
 struct WsRequestContext {
@@ -120,6 +128,16 @@ struct ConnectedUpstreamWebsocket {
     route_strategy: &'static str,
     route_source: &'static str,
 }
+
+struct StoredWsToolCallRegistry {
+    calls: CompletedWsToolCallCache,
+    last_used_at: Instant,
+    retained_bytes: usize,
+}
+
+static RESPONSES_WS_TOOL_CALL_REGISTRIES: OnceLock<
+    Mutex<HashMap<String, StoredWsToolCallRegistry>>,
+> = OnceLock::new();
 
 #[derive(Clone)]
 struct WsUpstreamAuthorization {
@@ -339,6 +357,130 @@ pub(super) async fn upgrade_responses_websocket(request: HttpRequest<Body>) -> R
         })
 }
 
+fn ws_tool_call_registry_key(
+    context: &WsRequestContext,
+    prepared: &PreparedClientFrame,
+) -> Option<String> {
+    // The frontend can add or omit prompt_cache_key when it opens the next task. If a
+    // session_id exists, use that stable root anchor instead of making the registry depend on
+    // the shape of an individual response.create frame.
+    let (route_conversation_id, _) = if context
+        .cache_affinity_key
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        ws_route_binding(context)
+    } else {
+        ws_route_binding_for_frame(context, prepared)
+    };
+    let route_conversation_id = route_conversation_id?.trim().to_string();
+    if route_conversation_id.is_empty() {
+        return None;
+    }
+    let model = prepared
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-");
+    Some(format!(
+        "{}:{}:{}:{}",
+        context.api_key.key_hash, context.api_key.protocol_type, model, route_conversation_id,
+    ))
+}
+
+fn store_ws_tool_call_registry(
+    context: &WsRequestContext,
+    prepared: &PreparedClientFrame,
+    observed: &CompletedWsToolCallCache,
+) {
+    if observed.is_empty() {
+        return;
+    }
+    let Some(key) = ws_tool_call_registry_key(context, prepared) else {
+        return;
+    };
+    let now = Instant::now();
+    let mutex = RESPONSES_WS_TOOL_CALL_REGISTRIES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut registries = mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registries.retain(|_, entry| {
+        now.duration_since(entry.last_used_at) <= RESPONSES_WS_TOOL_CALL_REGISTRY_TTL
+    });
+
+    let retained_bytes = {
+        let entry = registries
+            .entry(key.clone())
+            .or_insert_with(|| StoredWsToolCallRegistry {
+                calls: CompletedWsToolCallCache::default(),
+                last_used_at: now,
+                retained_bytes: 0,
+            });
+        entry.calls.merge_from(observed);
+        entry.last_used_at = now;
+        entry.retained_bytes = entry.calls.estimated_bytes();
+        entry.retained_bytes
+    };
+    if retained_bytes > RESPONSES_WS_MAX_TOOL_CALL_ENTRY_BYTES {
+        registries.remove(&key);
+        return;
+    }
+
+    let mut total_bytes = registries.values().fold(0usize, |total, entry| {
+        total.saturating_add(entry.retained_bytes)
+    });
+    while !registries.is_empty()
+        && (registries.len() > RESPONSES_WS_MAX_TOOL_CALL_REGISTRIES
+            || total_bytes > RESPONSES_WS_MAX_TOOL_CALL_REGISTRY_BYTES)
+    {
+        let oldest_key = registries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used_at)
+            .map(|(key, _)| key.clone());
+        let Some(oldest_key) = oldest_key else {
+            break;
+        };
+        if let Some(oldest) = registries.remove(&oldest_key) {
+            total_bytes = total_bytes.saturating_sub(oldest.retained_bytes);
+        }
+    }
+}
+
+fn load_ws_tool_call_registry(
+    context: &WsRequestContext,
+    prepared: &PreparedClientFrame,
+) -> Option<CompletedWsToolCallCache> {
+    let key = ws_tool_call_registry_key(context, prepared)?;
+    let now = Instant::now();
+    let mutex = RESPONSES_WS_TOOL_CALL_REGISTRIES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut registries = mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registries.retain(|_, entry| {
+        now.duration_since(entry.last_used_at) <= RESPONSES_WS_TOOL_CALL_REGISTRY_TTL
+    });
+    let entry = registries.get_mut(&key)?;
+    entry.last_used_at = now;
+    Some(entry.calls.clone())
+}
+
+fn remember_ws_tool_calls_from_input(context: &WsRequestContext, prepared: &PreparedClientFrame) {
+    let mut observed = CompletedWsToolCallCache::default();
+    observed.observe_input(&prepared.input);
+    store_ws_tool_call_registry(context, prepared, &observed);
+}
+
+fn remember_ws_tool_calls_from_upstream_event(
+    context: &WsRequestContext,
+    prepared: &PreparedClientFrame,
+    text: &str,
+) {
+    let mut observed = CompletedWsToolCallCache::default();
+    observed.observe_upstream_event(text);
+    store_ws_tool_call_registry(context, prepared, &observed);
+}
+
 async fn run_responses_websocket_session(mut socket: WebSocket, context: WsRequestContext) {
     let first_text = match receive_initial_request(&mut socket).await {
         Ok(Some(text)) => text,
@@ -364,6 +506,15 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
                 return;
             }
         };
+
+    let mut completed_tool_calls = if ws_request_has_tool_call_output(prepared_first.text.as_str())
+    {
+        load_ws_tool_call_registry(&context, &prepared_first).unwrap_or_default()
+    } else {
+        CompletedWsToolCallCache::default()
+    };
+    completed_tool_calls.observe_input(&prepared_first.input);
+    remember_ws_tool_calls_from_input(&context, &prepared_first);
 
     let mut first_log = begin_ws_request_log(
         &context,
@@ -410,7 +561,6 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
         retried_missing_tool_call_context: false,
     };
 
-    let mut completed_tool_calls = CompletedWsToolCallCache::default();
     let mut completed_responses = CompletedWsResponseCache::default();
     if let Err(err) = upstream
         .stream
@@ -586,6 +736,15 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
                                         break;
                                     }
                                 };
+                                if ws_request_has_tool_call_output(prepared.text.as_str()) {
+                                    if let Some(stored) =
+                                        load_ws_tool_call_registry(&context, &prepared)
+                                    {
+                                        completed_tool_calls.merge_from(&stored);
+                                    }
+                                }
+                                completed_tool_calls.observe_input(&prepared.input);
+                                remember_ws_tool_calls_from_input(&context, &prepared);
                                 let attempted_account_ids =
                                     HashSet::from([upstream.account_id.clone()]);
                                 let buffer_retry_preamble = should_buffer_ws_retry_preamble(
@@ -883,6 +1042,13 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
                 match upstream_result {
                     Ok(UpstreamMessage::Text(text)) => {
                         completed_tool_calls.observe_upstream_event(text.as_str());
+                        if let Some(pending) = pending_request.as_ref() {
+                            remember_ws_tool_calls_from_upstream_event(
+                                &context,
+                                &pending.prepared,
+                                text.as_str(),
+                            );
+                        }
                         if let Some(terminal) = inspect_ws_terminal_event(text.as_str()) {
                             if terminal.is_websocket_connection_limit {
                                 if let Some(pending) = pending_request.as_mut() {

--- a/crates/service/src/http/responses_websocket.rs
+++ b/crates/service/src/http/responses_websocket.rs
@@ -34,9 +34,9 @@ use crate::storage_helpers::open_storage;
 mod responses_websocket_rebase;
 
 use responses_websocket_rebase::{
-    expand_response_create_previous_response, rebase_response_create_for_account_change,
-    rebase_response_create_for_missing_tool_call, CompletedWsResponseCache,
-    CompletedWsToolCallCache, WsToolCallKind,
+    expand_response_create_previous_response, normalize_ws_tool_call_outputs,
+    rebase_response_create_for_account_change, rebase_response_create_for_missing_tool_call,
+    CompletedWsResponseCache, CompletedWsToolCallCache, WsToolCallKind,
 };
 
 const RESPONSES_WS_ERROR_CODE: &str = "responses_websocket_error";
@@ -969,7 +969,10 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
                                 &terminal,
                             );
                             let retry_result = if let Some(pending) = pending_request.as_mut() {
-                                if !pending.forwarded_upstream_event {
+                                if should_attempt_ws_terminal_retry(
+                                    terminal.status_code,
+                                    pending.forwarded_non_preamble_event,
+                                ) {
                                     try_retry_ws_request_after_terminal(
                                         &context,
                                         &mut upstream,
@@ -1647,6 +1650,18 @@ fn rewrite_client_frame(
     );
     if let Some(client_metadata) = merged_client_metadata {
         rewritten_object.insert("client_metadata".to_string(), client_metadata);
+    }
+
+    let duplicate_tool_outputs_dropped = rewritten_object
+        .get_mut("input")
+        .map(normalize_ws_tool_call_outputs)
+        .unwrap_or_default();
+    if duplicate_tool_outputs_dropped > 0 {
+        log::warn!(
+            "event=responses_ws_duplicate_tool_outputs_dropped count={} model={}",
+            duplicate_tool_outputs_dropped,
+            client_model_for_log.as_deref().unwrap_or("-")
+        );
     }
 
     let request: ResponseCreateWsRequest =
@@ -3481,6 +3496,10 @@ fn should_rotate_ws_upstream(status_code: u16) -> bool {
     matches!(status_code, 401 | 403 | 404 | 408 | 409 | 429)
 }
 
+fn should_attempt_ws_terminal_retry(status_code: u16, forwarded_non_preamble_event: bool) -> bool {
+    status_code != 200 && !forwarded_non_preamble_event
+}
+
 fn apply_ws_terminal_account_follow_up(account_id: &str, terminal: &WsTerminalEvent) {
     if !should_rotate_ws_upstream(terminal.status_code) {
         return;
@@ -3515,7 +3534,8 @@ async fn try_retry_ws_request_after_terminal(
     completed_responses: &CompletedWsResponseCache,
     completed_tool_calls: &CompletedWsToolCallCache,
 ) -> Result<bool, WsSessionError> {
-    if terminal.status_code == 200 || pending.forwarded_upstream_event {
+    if !should_attempt_ws_terminal_retry(terminal.status_code, pending.forwarded_non_preamble_event)
+    {
         return Ok(false);
     }
     let mut retry_text = None;

--- a/crates/service/src/http/responses_websocket_rebase.rs
+++ b/crates/service/src/http/responses_websocket_rebase.rs
@@ -41,7 +41,7 @@ struct WsToolCallKey {
     call_id: String,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(super) struct CompletedWsToolCallCache {
     calls: HashMap<WsToolCallKey, Value>,
     insertion_order: VecDeque<WsToolCallKey>,
@@ -90,7 +90,7 @@ impl CompletedWsToolCallCache {
             .trim()
             .to_ascii_lowercase();
         match event_type.as_str() {
-            "response.output_item.done" => {
+            "response.output_item.added" | "response.output_item.done" => {
                 if let Some(item) = value.get("item") {
                     self.insert(item);
                 }
@@ -108,6 +108,30 @@ impl CompletedWsToolCallCache {
             }
             _ => {}
         }
+    }
+
+    pub(super) fn observe_input(&mut self, input: &Value) {
+        match input {
+            Value::Array(items) => {
+                for item in items {
+                    self.insert(item);
+                }
+            }
+            Value::Null => {}
+            item => self.insert(item),
+        }
+    }
+
+    pub(super) fn merge_from(&mut self, other: &Self) {
+        for key in &other.insertion_order {
+            if let Some(item) = other.calls.get(key) {
+                self.insert(item);
+            }
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.calls.is_empty()
     }
 
     fn insert(&mut self, item: &Value) {
@@ -128,6 +152,16 @@ impl CompletedWsToolCallCache {
 
     fn get(&self, key: &WsToolCallKey) -> Option<&Value> {
         self.calls.get(key)
+    }
+
+    pub(super) fn estimated_bytes(&self) -> usize {
+        self.calls.iter().fold(0usize, |total, (key, value)| {
+            total.saturating_add(key.call_id.len()).saturating_add(
+                serde_json::to_vec(value)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or_default(),
+            )
+        })
     }
 }
 

--- a/crates/service/src/http/responses_websocket_rebase.rs
+++ b/crates/service/src/http/responses_websocket_rebase.rs
@@ -285,6 +285,35 @@ fn normalize_ws_response_input(input: &Value) -> Vec<Value> {
     }
 }
 
+/// Drops repeated tool outputs for the same `(kind, call_id)` pair.
+///
+/// The Codex tool runner can emit a second `custom_tool_call_output` when a
+/// host-side progress notification is attached to the same custom tool call.
+/// Responses accepts one output item per tool call, so preserve the first
+/// output and remove later duplicates before forwarding the request upstream.
+pub(super) fn normalize_ws_tool_call_outputs(input: &mut Value) -> usize {
+    let Some(items) = input.as_array_mut() else {
+        return 0;
+    };
+
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::with_capacity(items.len());
+    let mut removed = 0;
+    for item in items.drain(..) {
+        let Some(key) = ws_tool_output_key(&item).ok().flatten() else {
+            normalized.push(item);
+            continue;
+        };
+        if seen.insert(key) {
+            normalized.push(item);
+        } else {
+            removed += 1;
+        }
+    }
+    *items = normalized;
+    removed
+}
+
 pub(super) fn expand_response_create_previous_response(
     text: &str,
     completed_responses: &CompletedWsResponseCache,

--- a/crates/service/src/http/responses_websocket_tests.rs
+++ b/crates/service/src/http/responses_websocket_tests.rs
@@ -4,10 +4,10 @@ use super::{
     is_previous_response_not_found_terminal, merge_client_metadata,
     missing_ws_tool_call_from_terminal, parse_websocket_target, parse_ws_usage,
     prepare_missing_ws_tool_call_retry, proxy_basic_auth_header,
-    rebase_ws_request_for_account_change, rewrite_client_frame, should_buffer_ws_upstream_preamble,
-    strip_previous_response_id_from_ws_text, ws_request_has_tool_call_output,
-    ws_route_binding_for_frame, CompletedWsResponseCache, CompletedWsToolCallCache,
-    WsRequestContext, WsToolCallKind, WsUpstreamAuthorization,
+    rebase_ws_request_for_account_change, rewrite_client_frame, should_attempt_ws_terminal_retry,
+    should_buffer_ws_upstream_preamble, strip_previous_response_id_from_ws_text,
+    ws_request_has_tool_call_output, ws_route_binding_for_frame, CompletedWsResponseCache,
+    CompletedWsToolCallCache, WsRequestContext, WsToolCallKind, WsUpstreamAuthorization,
 };
 use axum::http::{HeaderMap, HeaderValue};
 use codexmanager_core::storage::{
@@ -177,6 +177,70 @@ fn websocket_frame_applies_model_fast_policy() {
     let value: Value = serde_json::from_str(&prepared.text).expect("parse overridden model frame");
     assert_eq!(prepared.model.as_deref(), Some("gpt-5.4-mini"));
     assert!(value.get("service_tier").is_none());
+}
+
+#[test]
+fn websocket_frame_drops_duplicate_tool_outputs_but_keeps_distinct_calls() {
+    let _guard = crate::test_env_guard();
+    let context = WsRequestContext {
+        api_key: sample_api_key(),
+        incoming_headers: sample_incoming_headers(None, None),
+        prompt_cache_key: None,
+        cache_affinity_key: None,
+        route_conversation_id: None,
+        route_conversation_source: None,
+        effective_upstream_base: "https://chatgpt.com/backend-api/codex".to_string(),
+        prefer_raw_errors: false,
+    };
+    let frame = json!({
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "call_id": "call_duplicate",
+                "name": "exec",
+                "input": "{}"
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_duplicate",
+                "output": [{ "type": "input_text", "text": "command result" }]
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_duplicate",
+                "output": "progress notification"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_function",
+                "output": "function result"
+            }
+        ]
+    });
+
+    let prepared = rewrite_client_frame(frame.to_string().as_str(), &context)
+        .expect("rewrite websocket frame");
+    let value: Value = serde_json::from_str(&prepared.text).expect("parse prepared frame");
+    let input = value["input"].as_array().expect("input array");
+
+    assert_eq!(input.len(), 3);
+    assert_eq!(input[0]["type"], "custom_tool_call");
+    assert_eq!(input[1]["type"], "custom_tool_call_output");
+    assert_eq!(input[1]["output"][0]["text"], "command result");
+    assert_eq!(input[2]["type"], "function_call_output");
+    assert_eq!(prepared.input, value["input"]);
+}
+
+#[test]
+fn websocket_terminal_retry_ignores_preamble_but_stops_after_real_output() {
+    assert!(
+        should_attempt_ws_terminal_retry(400, false),
+        "a response preamble has no non-preamble event and must not consume the retry opportunity"
+    );
+    assert!(!should_attempt_ws_terminal_retry(400, true));
+    assert!(!should_attempt_ws_terminal_retry(200, false));
 }
 
 fn sample_account() -> Account {

--- a/crates/service/src/http/responses_websocket_tests.rs
+++ b/crates/service/src/http/responses_websocket_tests.rs
@@ -1,13 +1,14 @@
 use super::{
     apply_model_fast_policy_with_storage, build_socks5_connect_request,
     build_upstream_websocket_request, infer_ws_terminal_status, inspect_ws_terminal_event,
-    is_previous_response_not_found_terminal, merge_client_metadata,
+    is_previous_response_not_found_terminal, load_ws_tool_call_registry, merge_client_metadata,
     missing_ws_tool_call_from_terminal, parse_websocket_target, parse_ws_usage,
     prepare_missing_ws_tool_call_retry, proxy_basic_auth_header,
-    rebase_ws_request_for_account_change, rewrite_client_frame, should_attempt_ws_terminal_retry,
-    should_buffer_ws_upstream_preamble, strip_previous_response_id_from_ws_text,
-    ws_request_has_tool_call_output, ws_route_binding_for_frame, CompletedWsResponseCache,
-    CompletedWsToolCallCache, WsRequestContext, WsToolCallKind, WsUpstreamAuthorization,
+    rebase_ws_request_for_account_change, remember_ws_tool_calls_from_upstream_event,
+    rewrite_client_frame, should_attempt_ws_terminal_retry, should_buffer_ws_upstream_preamble,
+    strip_previous_response_id_from_ws_text, ws_request_has_tool_call_output,
+    ws_route_binding_for_frame, CompletedWsResponseCache, CompletedWsToolCallCache,
+    WsRequestContext, WsToolCallKind, WsUpstreamAuthorization,
 };
 use axum::http::{HeaderMap, HeaderValue};
 use codexmanager_core::storage::{
@@ -241,6 +242,95 @@ fn websocket_terminal_retry_ignores_preamble_but_stops_after_real_output() {
     );
     assert!(!should_attempt_ws_terminal_retry(400, true));
     assert!(!should_attempt_ws_terminal_retry(200, false));
+}
+
+#[test]
+fn websocket_stale_tool_output_after_task_boundary_recovers_from_call_registry() {
+    let _guard = crate::test_env_guard();
+    let session_id = format!("stale-tool-output-{}-{}", std::process::id(), now_ts());
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "session_id",
+        HeaderValue::from_str(session_id.as_str()).expect("session header"),
+    );
+    let context = WsRequestContext {
+        api_key: sample_api_key(),
+        incoming_headers: crate::gateway::IncomingHeaderSnapshot::from_http_headers(&headers),
+        prompt_cache_key: None,
+        cache_affinity_key: Some(session_id),
+        route_conversation_id: None,
+        route_conversation_source: None,
+        effective_upstream_base: "https://chatgpt.com/backend-api/codex".to_string(),
+        prefer_raw_errors: false,
+    };
+    let seed = rewrite_client_frame(
+        r#"{"type":"response.create","model":"gpt-5.4","prompt_cache_key":"per-task-cache-key","input":"run cleanup"}"#,
+        &context,
+    )
+    .expect("rewrite seed response.create");
+    remember_ws_tool_calls_from_upstream_event(
+        &context,
+        &seed,
+        &json!({
+            "type": "response.output_item.added",
+            "item": {
+                "type": "custom_tool_call",
+                "id": "ctc_stale_task",
+                "call_id": "call_stale_task",
+                "name": "exec",
+                "input": "{}"
+            }
+        })
+        .to_string(),
+    );
+
+    // This is the exact failure shape: a new task sends the completed tool output,
+    // but no matching custom_tool_call exists in that task's input context.
+    let stale_request = rewrite_client_frame(
+        &json!({
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "input": [{
+                "type": "custom_tool_call_output",
+                "call_id": "call_stale_task",
+                "output": [
+                    {"type": "input_text", "text": "Script completed\nWall time: 0.2 seconds\nOutput:\n"},
+                    {"type": "input_text", "text": "MANIFESTS_REFRESHED=PASS"}
+                ]
+            }]
+        })
+        .to_string()
+        .as_str(),
+        &context,
+    )
+    .expect("rewrite stale task response.create");
+    assert!(stale_request.previous_response_id.is_none());
+    assert!(ws_request_has_tool_call_output(stale_request.text.as_str()));
+
+    let cached = load_ws_tool_call_registry(&context, &stale_request)
+        .expect("tool-call registry must survive the frontend task boundary");
+    let terminal = inspect_ws_terminal_event(
+        r#"{"type":"error","status":400,"error":{"type":"invalid_request_error","code":null,"message":"No tool call found for custom tool call output with call_id call_stale_task.","param":"input"}}"#,
+    )
+    .expect("exact upstream missing-tool terminal");
+    let mut already_retried = false;
+    let recovered = prepare_missing_ws_tool_call_retry(
+        stale_request.text.as_str(),
+        &cached,
+        &terminal,
+        &mut already_retried,
+    )
+    .expect("prepare stale-task recovery")
+    .expect("cached call must make the stale output self-contained");
+    let value: Value = serde_json::from_str(recovered.as_str()).expect("parse recovered request");
+    let input = value["input"].as_array().expect("recovered input array");
+    assert!(already_retried);
+    assert_eq!(input.len(), 2);
+    assert_eq!(input[0]["type"], "custom_tool_call");
+    assert_eq!(input[0]["call_id"], "call_stale_task");
+    assert_eq!(input[1]["type"], "custom_tool_call_output");
+    assert_eq!(input[1]["call_id"], "call_stale_task");
+    assert_eq!(input[1]["output"][1]["text"], "MANIFESTS_REFRESHED=PASS");
 }
 
 fn sample_account() -> Account {

--- a/crates/service/src/http/tests/proxy_runtime_tests.rs
+++ b/crates/service/src/http/tests/proxy_runtime_tests.rs
@@ -895,6 +895,125 @@ async fn start_mock_upstream_ws() -> (
     (addr.to_string(), event_rx, capture_rx, handle)
 }
 
+async fn start_mock_upstream_ws_recovers_stale_tool_output() -> (
+    String,
+    tokio::sync::mpsc::UnboundedReceiver<(usize, String)>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stale-tool-output mock upstream");
+    let addr = listener
+        .local_addr()
+        .expect("stale-tool-output mock upstream addr");
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let handle = tokio::spawn(async move {
+        for round in 0..2 {
+            let (stream, _) = listener
+                .accept()
+                .await
+                .expect("accept stale-tool-output upstream");
+            let mut websocket =
+                accept_hdr_async(stream, |_: &Request, response: Response| Ok(response))
+                    .await
+                    .expect("accept stale-tool-output websocket handshake");
+            let first_frame = match websocket.next().await {
+                Some(Ok(Message::Text(text))) => text.to_string(),
+                other => panic!("expected stale-tool-output response.create, got {other:?}"),
+            };
+            event_tx
+                .send((round, first_frame.clone()))
+                .expect("record stale-tool-output upstream frame");
+
+            if round == 0 {
+                for payload in [
+                    serde_json::json!({
+                        "type": "response.created",
+                        "response": { "id": "resp_stale_tool_seed" }
+                    }),
+                    serde_json::json!({
+                        "type": "response.output_item.done",
+                        "response_id": "resp_stale_tool_seed",
+                        "item": {
+                            "type": "custom_tool_call",
+                            "id": "ctc_stale_tool_seed",
+                            "call_id": "call_stale_task",
+                            "name": "exec",
+                            "input": "{}",
+                            "status": "completed"
+                        }
+                    }),
+                    serde_json::json!({
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stale_tool_seed",
+                            "status": "completed",
+                            "output": [{
+                                "type": "custom_tool_call",
+                                "id": "ctc_stale_tool_seed",
+                                "call_id": "call_stale_task",
+                                "name": "exec",
+                                "input": "{}",
+                                "status": "completed"
+                            }]
+                        }
+                    }),
+                ] {
+                    websocket
+                        .send(Message::Text(payload.to_string().into()))
+                        .await
+                        .expect("send stale-tool-output seed event");
+                }
+            } else {
+                websocket
+                    .send(Message::Text(
+                        serde_json::json!({
+                            "type": "error",
+                            "status": 400,
+                            "error": {
+                                "type": "invalid_request_error",
+                                "code": null,
+                                "message": "No tool call found for custom tool call output with call_id call_stale_task.",
+                                "param": "input"
+                            }
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await
+                    .expect("send exact stale-tool-output error");
+                let retry_frame = match websocket.next().await {
+                    Some(Ok(Message::Text(text))) => text.to_string(),
+                    other => panic!("expected recovered response.create, got {other:?}"),
+                };
+                event_tx
+                    .send((round, retry_frame))
+                    .expect("record recovered stale-tool-output frame");
+                for payload in [
+                    serde_json::json!({
+                        "type": "response.created",
+                        "response": { "id": "resp_stale_tool_recovered" }
+                    }),
+                    serde_json::json!({
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_stale_tool_recovered",
+                            "status": "completed",
+                            "output": []
+                        }
+                    }),
+                ] {
+                    websocket
+                        .send(Message::Text(payload.to_string().into()))
+                        .await
+                        .expect("send recovered stale-tool-output event");
+                }
+            }
+        }
+    });
+    (addr.to_string(), event_rx, handle)
+}
+
 async fn start_mock_upstream_ws_resets_before_first_frame() -> (
     String,
     tokio::sync::mpsc::UnboundedReceiver<(usize, String)>,
@@ -4795,4 +4914,178 @@ async fn official_responses_websocket_rebases_tool_output_on_next_account() {
         .await
         .expect("mock upstream shutdown timeout")
         .expect("join mock upstream");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn official_responses_websocket_recovers_stale_tool_output_after_task_boundary() {
+    let _guard = crate::test_env_guard();
+    let db_path = new_test_db_path("codexmanager-proxy-runtime-ws-stale-tool-output");
+    let storage = init_test_storage(&db_path);
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+    let (upstream_addr, mut upstream_events, upstream_handle) =
+        start_mock_upstream_ws_recovers_stale_tool_output().await;
+    insert_api_key_record(
+        &storage,
+        "platform_key_ws_stale_tool_output",
+        crate::apikey_profile::ROTATION_ACCOUNT,
+        Some(format!(
+            "http://{upstream_addr}/chatgpt.com/backend-api/codex"
+        )),
+    );
+    insert_account_and_token(&storage);
+    tokio::task::spawn_blocking(|| {
+        crate::gateway::reload_runtime_config_from_env();
+        let _ = crate::gateway::front_proxy_max_body_bytes();
+    })
+    .await
+    .expect("reload runtime config");
+
+    let state = ProxyState {
+        backend_base_url: "http://127.0.0.1:1".to_string(),
+        client: Client::new(),
+    };
+    let (front_addr, shutdown_tx, server_handle) = start_front_proxy_test_server(state).await;
+    let headers = [
+        ("OpenAI-Beta", "responses_websockets=2026-02-06"),
+        ("session_id", "session_ws_stale_tool_output"),
+    ];
+
+    let request = build_ws_request(
+        &format!("ws://{front_addr}/v1/responses"),
+        "platform_key_ws_stale_tool_output",
+        &headers,
+    );
+    let (mut seed_ws, response) = connect_async(request)
+        .await
+        .expect("seed websocket connects");
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+    seed_ws
+        .send(Message::Text(
+            serde_json::json!({
+                "type": "response.create",
+                "model": "gpt-4.1",
+                "prompt_cache_key": "per-task-cache-key",
+                "input": "seed task"
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send seed response.create");
+
+    let (round, seed_frame) = tokio::time::timeout(Duration::from_secs(5), upstream_events.recv())
+        .await
+        .expect("seed upstream frame timeout")
+        .expect("seed upstream frame");
+    assert_eq!(round, 0);
+    let seed_payload: serde_json::Value =
+        serde_json::from_str(seed_frame.as_str()).expect("parse seed upstream frame");
+    assert_eq!(seed_payload["type"], "response.create");
+
+    for expected_type in [
+        "response.created",
+        "response.output_item.done",
+        "response.completed",
+    ] {
+        let event = tokio::time::timeout(Duration::from_secs(5), seed_ws.next())
+            .await
+            .expect("seed client event timeout")
+            .expect("seed client event")
+            .expect("seed client event result");
+        let Message::Text(text) = event else {
+            panic!("unexpected seed client event: {event:?}");
+        };
+        let payload: serde_json::Value =
+            serde_json::from_str(&text).expect("parse seed client event");
+        assert_eq!(payload["type"], expected_type);
+    }
+    seed_ws.close(None).await.expect("close seed websocket");
+
+    let request = build_ws_request(
+        &format!("ws://{front_addr}/v1/responses"),
+        "platform_key_ws_stale_tool_output",
+        &headers,
+    );
+    let (mut follow_up_ws, response) = connect_async(request)
+        .await
+        .expect("follow-up websocket connects");
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+    follow_up_ws
+        .send(Message::Text(
+            serde_json::json!({
+                "type": "response.create",
+                "model": "gpt-4.1",
+                "input": [{
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_stale_task",
+                    "output": [
+                        {"type": "input_text", "text": "Script completed\nWall time: 0.2 seconds\nOutput:\n"},
+                        {"type": "input_text", "text": "MANIFESTS_REFRESHED=PASS"}
+                    ]
+                }]
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send stale task response.create");
+
+    let (round, first_attempt) =
+        tokio::time::timeout(Duration::from_secs(5), upstream_events.recv())
+            .await
+            .expect("stale first-attempt upstream frame timeout")
+            .expect("stale first-attempt upstream frame");
+    assert_eq!(round, 1);
+    let first_attempt: serde_json::Value =
+        serde_json::from_str(first_attempt.as_str()).expect("parse stale first-attempt frame");
+    assert_eq!(first_attempt["type"], "response.create");
+    assert_eq!(first_attempt["input"][0]["type"], "custom_tool_call_output");
+    assert_eq!(first_attempt["input"].as_array().map(Vec::len), Some(1));
+
+    let (round, recovered_attempt) =
+        tokio::time::timeout(Duration::from_secs(5), upstream_events.recv())
+            .await
+            .expect("recovered upstream frame timeout")
+            .expect("recovered upstream frame");
+    assert_eq!(round, 1);
+    let recovered_attempt: serde_json::Value =
+        serde_json::from_str(recovered_attempt.as_str()).expect("parse recovered frame");
+    assert_eq!(recovered_attempt["type"], "response.create");
+    assert!(recovered_attempt.get("previous_response_id").is_none());
+    assert_eq!(recovered_attempt["input"][0]["type"], "custom_tool_call");
+    assert_eq!(recovered_attempt["input"][0]["call_id"], "call_stale_task");
+    assert_eq!(
+        recovered_attempt["input"][1]["type"],
+        "custom_tool_call_output"
+    );
+    assert_eq!(recovered_attempt["input"][1]["call_id"], "call_stale_task");
+
+    for expected_type in ["response.created", "response.completed"] {
+        let event = tokio::time::timeout(Duration::from_secs(5), follow_up_ws.next())
+            .await
+            .expect("recovered client event timeout")
+            .expect("recovered client event")
+            .expect("recovered client event result");
+        let Message::Text(text) = event else {
+            panic!("unexpected recovered client event: {event:?}");
+        };
+        let payload: serde_json::Value =
+            serde_json::from_str(&text).expect("parse recovered client event");
+        assert_eq!(payload["type"], expected_type);
+        assert_ne!(payload["type"], "error");
+    }
+
+    follow_up_ws
+        .close(None)
+        .await
+        .expect("close follow-up websocket");
+    let _ = shutdown_tx.send(());
+    tokio::time::timeout(Duration::from_secs(5), server_handle)
+        .await
+        .expect("front proxy shutdown timeout")
+        .expect("join front proxy");
+    tokio::time::timeout(Duration::from_secs(5), upstream_handle)
+        .await
+        .expect("stale-tool-output mock upstream shutdown timeout")
+        .expect("join stale-tool-output mock upstream");
 }


### PR DESCRIPTION
## 摘要

本 PR 加固 Responses WebSocket 请求链路：对重复工具输出进行归一化，并区分连接前导事件与实质输出，确保终止恢复逻辑按正确边界执行。
